### PR TITLE
Bump original version number instead of date written by MELPA

### DIFF
--- a/swoop.el
+++ b/swoop.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/ShingoFukuyama/swoop
 ;; Created: Feb 14 2014
 ;; Keywords: swoop inner buffer search navigation
-;; Package-Requires: ((pcre2el "20130620.1810") (async "1.1") (emacs "24"))
+;; Package-Requires: ((pcre2el "1.5") (async "1.1") (emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as


### PR DESCRIPTION
When a package is installed by MELPA, MELPA bump date to Version header and bump the original version number to X-Original-Version header.
